### PR TITLE
Added support for Bearer token in rest connector

### DIFF
--- a/connector-rest/src/main/java/com/evolveum/polygon/rest/AbstractRestConfiguration.java
+++ b/connector-rest/src/main/java/com/evolveum/polygon/rest/AbstractRestConfiguration.java
@@ -26,7 +26,7 @@ import org.identityconnectors.framework.spi.ConfigurationProperty;
 public class AbstractRestConfiguration extends AbstractConfiguration {
 	
 	public enum AuthMethod {
-        NONE, BASIC, TOKEN
+        NONE, BASIC, TOKEN, BEARER_TOKEN
 	}
 	
 	private String serviceAddress = null;

--- a/connector-rest/src/main/java/com/evolveum/polygon/rest/AbstractRestConnector.java
+++ b/connector-rest/src/main/java/com/evolveum/polygon/rest/AbstractRestConnector.java
@@ -106,6 +106,9 @@ public abstract class AbstractRestConnector<C extends AbstractRestConfiguration>
             case TOKEN:
                 break;
 
+            case BEARER_TOKEN:
+                break;
+
             default:
 
                 throw new IllegalArgumentException("Unknown authentication method " + getConfiguration().getAuthMethod());
@@ -155,7 +158,8 @@ public abstract class AbstractRestConnector<C extends AbstractRestConfiguration>
      */
     public CloseableHttpResponse execute(HttpUriRequest request) {
         try {
-            if (AbstractRestConfiguration.AuthMethod.TOKEN.name().equals(getConfiguration().getAuthMethod())) {
+            if (AbstractRestConfiguration.AuthMethod.TOKEN.name().equals(getConfiguration().getAuthMethod()) ||
+                AbstractRestConfiguration.AuthMethod.BEARER_TOKEN.name().equals(getConfiguration().getAuthMethod())) {
 
                 final StringBuilder token = new StringBuilder();
                 if (getConfiguration().getTokenValue() != null) {
@@ -167,7 +171,12 @@ public abstract class AbstractRestConnector<C extends AbstractRestConfiguration>
                     });
                 }
 
-                request.setHeader(getConfiguration().getTokenName(), token.toString());
+                if (AbstractRestConfiguration.AuthMethod.TOKEN.name().equals(getConfiguration().getAuthMethod())) {
+                    request.setHeader(getConfiguration().getTokenName(), token.toString());
+                } else {
+                    request.setHeader("Authorization", "Bearer " + token.toString());
+                }
+
             }
             return getHttpClient().execute(request);
         } catch (IOException e) {


### PR DESCRIPTION
It's not uncommon practice (for example [1], [2], [3]) to use token in form of "Authorization: Bearer \<token\>" HTTP header instead of custom one (which what connector-rest supports now with tokenName configuration). 

This small patch adds ability to easily use this form.

[1] https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
[2] https://social.technet.microsoft.com/wiki/contents/articles/53488.azure-rest-api-how-to-create-bearer-token.aspx
[3] https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_bearer.html
